### PR TITLE
Closes #43 Fix integer overflow with field in_bytes / out_bytes

### DIFF
--- a/backend/models/Connection.cs
+++ b/backend/models/Connection.cs
@@ -37,12 +37,12 @@ namespace backend.models
         public DateTime last_activity { get; set; }
         public string rtt { get; set; }
         public string uptime { get; set; }
-        public int pending_byten { get; set; }
-        public int in_msgs { get; set; }
-        public int out_msgs { get; set; }
-        public int in_bytes { get; set; }
-        public int out_bytes { get; set; }
-        public int subscriptions { get; set; }
+        public long pending_byten { get; set; }
+        public long in_msgs { get; set; }
+        public long out_msgs { get; set; }
+        public long in_bytes { get; set; }
+        public long out_bytes { get; set; }
+        public long subscriptions { get; set; }
         public string lang { get; set; }
         public string version { get; set; } 
 

--- a/backend/models/Gateway.cs
+++ b/backend/models/Gateway.cs
@@ -23,11 +23,11 @@ namespace backend
             public string rtt { get; set; }
             public string uptime { get; set; }
             public string idle { get; set; }
-            public int pending_bytes { get; set; }
-            public int in_msgs { get; set; }
-            public int out_msgs { get; set; }
-            public int in_bytes { get; set; }
-            public int out_bytes { get; set; }
+            public long pending_bytes { get; set; }
+            public long in_msgs { get; set; }
+            public long out_msgs { get; set; }
+            public long in_bytes { get; set; }
+            public long out_bytes { get; set; }
             public int subscriptions { get; set; }
             public string name { get; set; }
             


### PR DESCRIPTION
<!-- Please include a summary of the change and which issue it fixes. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The number in the field in_bytes and out_bytes was higher than an integer allowed, so for now its been changed to long. This would allow for 8 million terabytes to be exchanged between any two clusters, so call me in 20 years when that will be a problem

# Type of change

Please check all boxes that apply to this change below.

| Type                     | Applies ✅|
| ------------------------ | :-------: |
| Backend                  |     ✅     |
| Frontend                 |           |
| Github/Ci/Admin          |           |
| Documentation required   |           |

# Checklist

Please follow the checklist below and check all completed items as you work on the PR.

I have..
- [x] performed a self-review of my own code
- [ ] commented my code, particularly in hard-to-understand areas
- [ ] written documentation
- [ ] added automated tests
- [ ] merged dependencies to `develop
