### PR TITLE
Display node information in sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1965,7 +1965,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@types/q": {
       "version": "1.5.4",
@@ -2352,6 +2353,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -2361,6 +2363,7 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
           "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -2371,6 +2374,7 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -2379,13 +2383,15 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cosmiconfig": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
           "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/parse-json": "^4.0.0",
             "import-fresh": "^3.1.0",
@@ -2399,6 +2405,7 @@
           "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
           "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@babel/code-frame": "^7.8.3",
             "@types/json-schema": "^7.0.5",
@@ -2418,6 +2425,7 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
           "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -2429,13 +2437,15 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "import-fresh": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
           "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
@@ -2446,6 +2456,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
           "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
@@ -2456,6 +2467,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
           "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
@@ -2467,19 +2479,22 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "schema-utils": {
           "version": "2.7.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
           "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/json-schema": "^7.0.4",
             "ajv": "^6.12.2",
@@ -2491,6 +2506,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -2499,7 +2515,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2601,6 +2618,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -2610,6 +2628,7 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
           "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -2620,6 +2639,7 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -2628,19 +2648,22 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loader-utils": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
           "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -2662,6 +2685,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -2671,6 +2695,7 @@
           "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.2.0.tgz",
           "integrity": "sha512-TitGhqSQ61RJljMmhIGvfWzJ2zk9m1Qug049Ugml6QP3t0e95o0XJjk29roNEiPKJQBEi8Ord5hFuSuELzSp8Q==",
           "dev": true,
+          "optional": true,
           "requires": {
             "chalk": "^4.1.0",
             "hash-sum": "^2.0.0",
@@ -3326,7 +3351,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "atob": {
       "version": "2.1.2",
@@ -6984,7 +7010,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
       "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -9479,6 +9506,7 @@
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.2.tgz",
       "integrity": "sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "fs-monkey": "1.0.3"
       }
@@ -10517,6 +10545,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "callsites": "^3.0.0"
       },
@@ -10525,7 +10554,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
           "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13074,7 +13104,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "terser": {
       "version": "4.8.0",
@@ -14051,6 +14082,11 @@
         "tsconfig": "^7.0.0",
         "vue-template-es2015-compiler": "^1.6.0"
       }
+    },
+    "vue-json-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/vue-json-component/-/vue-json-component-0.4.1.tgz",
+      "integrity": "sha512-8Tw4C5LJOT09BRKjQx8F5itheP7UIeZtUUJvWnSltb0UFQZSrXw/4B32z3pelWo38MtoglaSmFTYpyxFIWWNRg=="
     },
     "vue-loader": {
       "version": "15.9.6",
@@ -15245,7 +15281,8 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "node-notifier": ">=8.0.1",
     "vue": "^2.6.12",
     "vue-class-component": "^7.2.3",
+    "vue-json-component": "^0.4.1",
     "vue-panzoom": "^1.1.6",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.2.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,8 +39,8 @@ export default {
     Searchbar,
     InfoPanel
   },
-  data (): { 
-    servers: ServerDatum[]; 
+  data (): {
+    servers: ServerDatum[];
     routes: RouteDatum[];
     clusters: ClusterDatum[];
     gateways: GatewayDatum[];
@@ -71,8 +71,8 @@ export default {
 
       return true
     },
-    onNodeClick () {
-      this.$refs.panel.onNodeClick()
+    onNodeClick (nodeData) {
+      this.$refs.panel.onNodeClick(nodeData)
     },
     onSearchInput (text: string) {
       this.$refs.graph.searchFilter(text)

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,8 +71,8 @@ export default {
 
       return true
     },
-    onNodeClick (nodeData) {
-      this.$refs.panel.onNodeClick(nodeData)
+    onNodeClick ({nodeData, id}) {
+      this.$refs.panel.onNodeClick({nodeData, id})
     },
     onSearchInput (text: string) {
       this.$refs.graph.searchFilter(text)

--- a/src/components/Graph/Graph.vue
+++ b/src/components/Graph/Graph.vue
@@ -258,12 +258,8 @@ export default {
         .style('opacity', d => d.isSearchMatch ? 1.0 : 0.2)
         .call(this.drag(simulation)) // Handle dragging of the nodes
         .on('click', (d, i) => { // Log the value of the chosen node on click
-          this.$emit('node-click')
-
           axios.get('https://localhost:5001/varz/' + i.server_id).then(a => {
-            console.log(d)
-            console.log(i)
-            console.log(a.data)
+            this.$emit('node-click', a.data)
           })
         })
 

--- a/src/components/Graph/Graph.vue
+++ b/src/components/Graph/Graph.vue
@@ -256,10 +256,11 @@ export default {
         .attr('r', 5)
         .attr('fill', d => d.ntv_error ? '#f00' : '#000') // Make node red if it has error
         .style('opacity', d => d.isSearchMatch ? 1.0 : 0.2)
+        .style('cursor', 'pointer')
         .call(this.drag(simulation)) // Handle dragging of the nodes
         .on('click', (d, i) => { // Log the value of the chosen node on click
           axios.get('https://localhost:5001/varz/' + i.server_id).then(a => {
-            this.$emit('node-click', a.data)
+            this.$emit('node-click', {nodeData: a.data, id: i.server_id})
           })
         })
 

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -10,7 +10,10 @@
       width="400px"
       v-model="isPanelOpen">
       <div class="px-3 py-2">
-        <json-view :data="nodeData" :root-key="rootName"/>
+        <p id="error">The selected node does not exist.</p>
+        <div id="info">
+          <json-view :data="nodeData" :root-key="rootName"/>
+        </div>
       </div>
     </b-sidebar>
   </div>
@@ -34,7 +37,18 @@ export default {
       if (!this.$data.isPanelOpen) {
         this.$data.isPanelOpen = true
       }
-      this.nodeData = nodeData
+
+      const info = document.getElementById("info")
+      const error = document.getElementById("error")
+
+      if (nodeData === '') {
+        info.style.display = "none"
+        error.style.display = "block"
+      } else {
+        info.style.display = "block"
+        error.style.display = "none"
+        this.nodeData = nodeData
+      }
     }
   }
 }

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -9,7 +9,7 @@
       shadow=true
       width="400px"
       v-model="isPanelOpen">
-      <div class="px-3 py-2" id="info">
+      <div class="px-3 py-2">
         <table>
           <tr>
             <th>Name</th>
@@ -48,8 +48,13 @@ export default {
 }
 </script>
 
-<style scoped>
-#info {
-  overflow-x: hidden;
+<style>
+table {
+  table-layout: fixed;
+  width: 360px;
+}
+td {
+  word-wrap: break-word;
+  vertical-align: text-top;
 }
 </style>

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -10,16 +10,7 @@
       width="400px"
       v-model="isPanelOpen">
       <div class="px-3 py-2">
-        <table>
-          <tr>
-            <th>Name</th>
-            <th>Value</th>
-          </tr>
-          <tr v-for="(value, key) in nodeData">
-            <td>{{ key }}</td>
-            <td>{{ value }}</td>
-          </tr>
-        </table>
+        <json-view :data="nodeData" :root-key="rootName"/>
       </div>
     </b-sidebar>
   </div>
@@ -34,7 +25,8 @@ export default {
   data () {
     return {
       isPanelOpen: false,
-      nodeData: null
+      nodeData: null,
+      rootName: 'node'
     }
   },
   methods: {
@@ -48,13 +40,6 @@ export default {
 }
 </script>
 
-<style>
-table {
-  table-layout: fixed;
-  width: 360px;
-}
-td {
-  word-wrap: break-word;
-  vertical-align: text-top;
-}
+<style scoped>
+
 </style>

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -2,17 +2,24 @@
   <div>
     <b-sidebar
       id="sidepanel"
-      title="Useful information"
+      title="Node information"
       right
       backdrop-variant="transparent"
       backdrop
       shadow=true
+      width="400px"
       v-model="isPanelOpen">
-      <div class="px-3 py-2">
-        <p>
-          Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis
-          in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
-        </p>
+      <div class="px-3 py-2" id="info">
+        <table>
+          <tr>
+            <th>Name</th>
+            <th>Value</th>
+          </tr>
+          <tr v-for="(value, key) in nodeData">
+            <td>{{ key }}</td>
+            <td>{{ value }}</td>
+          </tr>
+        </table>
       </div>
     </b-sidebar>
   </div>
@@ -26,19 +33,23 @@ export default {
   components: { SidebarPanel },
   data () {
     return {
-      isPanelOpen: false
+      isPanelOpen: false,
+      nodeData: null
     }
   },
   methods: {
-    onNodeClick () {
+    onNodeClick (nodeData) {
       if (!this.$data.isPanelOpen) {
         this.$data.isPanelOpen = true
       }
+      this.nodeData = nodeData
     }
   }
 }
 </script>
 
 <style scoped>
-
+#info {
+  overflow-x: hidden;
+}
 </style>

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -4,8 +4,6 @@
       id="sidepanel"
       title="Node information"
       right
-      backdrop-variant="transparent"
-      backdrop
       shadow=true
       width="400px"
       v-model="isPanelOpen">

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -8,7 +8,10 @@
       width="450px"
       v-model="isPanelOpen">
       <div class="px-3 py-2">
-        <p id="error">The selected node does not exist.</p>
+        <div id="error">
+          <p>The selected node does not exist. <br><br> server_id:</p>
+          <p id="errorid">"{{ errorId }}"</p>
+        </div>
         <div id="info">
           <json-view :data="nodeData" :root-key="rootName"/>
         </div>
@@ -27,11 +30,12 @@ export default {
     return {
       isPanelOpen: false,
       nodeData: null,
-      rootName: 'node'
+      rootName: 'node',
+      errorId: ''
     }
   },
   methods: {
-    onNodeClick (nodeData) {
+    onNodeClick ({nodeData, id}) {
       if (!this.$data.isPanelOpen) {
         this.$data.isPanelOpen = true
       }
@@ -42,6 +46,7 @@ export default {
       if (nodeData === '') {
         info.style.display = "none"
         error.style.display = "block"
+        this.errorId = id
       } else {
         info.style.display = "block"
         error.style.display = "none"
@@ -53,5 +58,16 @@ export default {
 </script>
 
 <style scoped>
+
+#errorid {
+  word-wrap: break-word;
+  color: #268bd2;
+  font-weight: 600;
+  margin-top: -15px;
+}
+
+#error {
+  font-weight: 600;
+}
 
 </style>

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -5,7 +5,7 @@
       title="Node information"
       right
       shadow=true
-      width="400px"
+      width="450px"
       v-model="isPanelOpen">
       <div class="px-3 py-2">
         <p id="error">The selected node does not exist.</p>

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,8 @@ import BootstrapVue from 'bootstrap-vue'
 import VueZoomer from 'vue-zoomer'
 // @ts-ignore
 import Panzoom from 'vue-panzoom'
-//import Panzoom from '@panzoom/panzoom'
+
+import JSONView from 'vue-json-component'
 
 import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
@@ -18,7 +19,7 @@ Vue.config.productionTip = false
 
 Vue.use(BootstrapVue)
 Vue.use(VueZoomer)
-//Vue.use(Panzoom)
+Vue.use(JSONView)
 
 new Vue({
   router,


### PR DESCRIPTION
<!-- Please include a summary of the change and which issue it fixes. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Thorsten and I have managed to display the node information using a library. However, using this library means we can't remove the horizontal scroll bar - at least I haven't found a way to do so. Feel free to experiment with that yourself!

We have also removed the backdrop so that you can click several nodes in succession and see their information without the panel closing first. However this means that you have to click the X to close it. If we still want the panel to close when clicking anywhere (apart from nodes), maybe it is possible to add a click event to the SVG or something. I tried that for a bit but couldn't get it working.

# Type of change

Please check all boxes that apply to this change below.

| Type                     | Applies ✅|
| ------------------------ | :-------: |
| Backend                  |           |
| Frontend                 |     ✅     |
| Github/Ci/Admin          |           |
| Documentation required   |           |

# Checklist

Please follow the checklist below and check all completed items as you work on the PR.

I have..
- [x] performed a self-review of my own code
- [ ] commented my code, particularly in hard-to-understand areas
- [ ] written documentation
- [ ] added automated tests
- [ ] merged dependencies to `develop
